### PR TITLE
fix (build): Added helpers folder to files in preset-create-react-app

### DIFF
--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -15,6 +15,7 @@
   "files": [
     "create-react-app.js",
     "index.d.ts"
+    "helpers/"
   ],
   "scripts": {
     "storybook": "start-storybook -p 8008"

--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -15,7 +15,7 @@
   "files": [
     "create-react-app.js",
     "index.d.ts",
-    "helpers/"
+    "helpers"
   ],
   "scripts": {
     "storybook": "start-storybook -p 8008"

--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -14,7 +14,7 @@
   },
   "files": [
     "create-react-app.js",
-    "index.d.ts"
+    "index.d.ts",
     "helpers/"
   ],
   "scripts": {


### PR DESCRIPTION
Hello, when testing https://github.com/storybookjs/presets/pull/25 I discovered that `helpers` directory is to been published. This PR fixes it.

Edit:
Tested locally
![image](https://user-images.githubusercontent.com/1002461/62930969-c39fa900-bdbd-11e9-87ba-e24b4ed0c247.png)