### PR TITLE
add preset-typescript tsloader-option to README.md.

### DIFF
--- a/packages/preset-typescript/README.md
+++ b/packages/preset-typescript/README.md
@@ -25,6 +25,9 @@ module.exports = [
   {
     name: "@storybook/preset-typescript",
     options: {
+      tsLoaderOptions: {
+        configFile: path.resolve(__dirname, '../tsconfig.json'),
+      },
       tsDocgenLoaderOptions: {
         tsconfigPath: path.resolve(__dirname, "../tsconfig.json")
       },


### PR DESCRIPTION
I think so `tsLoaderOptions` is documented important than `tsDocgenLoaderOptions`.