### PR TITLE
Add passWithNoTests flag at jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "yarn lint:js .",
     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.json --report-unused-disable-directives",
     "repo-dirty-check": "node ./scripts/repo-dirty-check",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
Now always fail test. Because of No tests found.

```
$ jest
No tests found
In /home/circleci/repo
  26 files checked.
  testMatch: **/__tests__/**/*.js?(x),**/?(*.)+(spec|test).js?(x) - 0 matches
  testPathIgnorePatterns: /node_modules/ - 26 matches
Pattern:  - 0 matches
error Command failed with exit code 1.
```

Added [passWithNoTests flag](https://jestjs.io/docs/en/cli#passwithnotests) at jest.