### PR TITLE
feat/fix: remove tsdocgen option and resolve ts paths

### DIFF
--- a/packages/preset-create-react-app/.storybook/presets.js
+++ b/packages/preset-create-react-app/.storybook/presets.js
@@ -2,7 +2,7 @@ module.exports = [
   {
     name: '@storybook/preset-create-react-app',
     options: {
-      useTsDocgenLoader: true,
+      tsDocgenLoaderOptions: {},
     }
   },
 ];

--- a/packages/preset-create-react-app/README.md
+++ b/packages/preset-create-react-app/README.md
@@ -34,7 +34,6 @@ module.exports = [
     name: '@storybook/preset-create-react-app',
     options: {
       scriptsPackageName: '@my/react-scripts',
-      useTsDocgenLoader: true,
       tsDocgenLoaderOptions: {},
     },
   },

--- a/packages/preset-create-react-app/helpers/getModulePath.js
+++ b/packages/preset-create-react-app/helpers/getModulePath.js
@@ -16,9 +16,9 @@ const getModulePath = appDirectory => {
   try {
     // eslint-disable-next-line import/no-dynamic-require,global-require
     const config = require(path.join(appDirectory, configName));
-    return config.compilerOptions.baseUrl;
+    return [config.compilerOptions.baseUrl];
   } catch (e) {
-    return false;
+    return [];
   }
 };
 

--- a/packages/preset-create-react-app/helpers/getModulePath.js
+++ b/packages/preset-create-react-app/helpers/getModulePath.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const JSCONFIG = 'jsconfig.json';
+const TSCONFIG = 'tsconfig.json';
+
+const getModulePath = appDirectory => {
+  // CRA only supports `jsconfig.json` if `tsconfig.json` doesn't exist.
+  let configName;
+  if (fs.existsSync(path.join(appDirectory, TSCONFIG))) {
+    configName = TSCONFIG;
+  } else if (fs.existsSync(path.join(appDirectory, JSCONFIG))) {
+    configName = JSCONFIG;
+  }
+
+  try {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    const config = require(path.join(appDirectory, configName));
+    return config.compilerOptions.baseUrl;
+  } catch (e) {
+    return false;
+  }
+};
+
+module.exports = getModulePath;

--- a/packages/preset-create-react-app/index.js
+++ b/packages/preset-create-react-app/index.js
@@ -81,7 +81,7 @@ const webpack = (webpackConfig = {}, options = {}) => {
       modules: [
         ...webpackConfig.resolve.modules,
         path.join(REACT_SCRIPTS_PATH, 'node_modules'),
-        ...[getModulePath(CWD)],
+        ...getModulePath(CWD),
       ],
     },
     resolveLoader,

--- a/packages/preset-create-react-app/index.js
+++ b/packages/preset-create-react-app/index.js
@@ -59,7 +59,7 @@ const webpack = (webpackConfig = {}, options = {}) => {
   logger.info(`=> Modifying Create React App rules.`);
   const craRules = processCraConfig(craWebpackConfig, options);
 
-  const tsDocgenRule = options.useTsDocgenLoader
+  const tsDocgenRule = options.tsDocgenLoaderOptions
     ? {
         test: /\.tsx?$/,
         loader: require.resolve('react-docgen-typescript-loader'),

--- a/packages/preset-create-react-app/index.js
+++ b/packages/preset-create-react-app/index.js
@@ -4,6 +4,7 @@ const mergePlugins = require('./helpers/mergePlugins');
 const getReactScriptsPath = require('./helpers/getReactScriptsPath');
 const processCraConfig = require('./helpers/processCraConfig');
 const checkPresets = require('./helpers/checkPresets');
+const getModulePath = require('./helpers/getModulePath');
 
 const CWD = process.cwd();
 const REACT_SCRIPTS_PATH = getReactScriptsPath();
@@ -77,7 +78,11 @@ const webpack = (webpackConfig = {}, options = {}) => {
     resolve: {
       ...webpackConfig.resolve,
       extensions: craWebpackConfig.resolve.extensions,
-      modules: [...webpackConfig.resolve.modules, path.join(REACT_SCRIPTS_PATH, 'node_modules')],
+      modules: [
+        ...webpackConfig.resolve.modules,
+        path.join(REACT_SCRIPTS_PATH, 'node_modules'),
+        ...[getModulePath(CWD)],
+      ],
     },
     resolveLoader,
   };

--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/preset-create-react-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Create React App preset for Storybook",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
This PR removes the need to set `useTsDocgenLoader`, and updates path resolution for TS projects.