### PR TITLE
Fixed bug in Windows scripts dir resolution regex (closes #48)

### DIFF
--- a/packages/preset-create-react-app/helpers/getReactScriptsPath.js
+++ b/packages/preset-create-react-app/helpers/getReactScriptsPath.js
@@ -13,7 +13,7 @@ const getReactScriptsPath = () => {
     try {
       const content = fs.readFileSync(scriptsBinPath, 'utf8');
       const packagePathMatch = content.match(
-        /"\$basedir[\\/]([^\s]+?[\\/]bin[\\/]react-scripts\.js")/i
+        /"\$basedir[\\/](\S+?)[\\/]bin[\\/]react-scripts\.js"/i
       );
 
       if (packagePathMatch && packagePathMatch.length > 1) {


### PR DESCRIPTION
Hello,

I fixed the bug that was breaking Windows react-scripts resolution. It was just an erroneous regex that was capturing the entire path when it needed to clip the "\bin\react-scripts.js."

Thanks for the useful package!

Matt

Closes #48 