### PR TITLE
Preset-typescript: Use fork-ts-checker-webpack-plugin

### DIFF
--- a/packages/preset-typescript/.storybook/presets.ts
+++ b/packages/preset-typescript/.storybook/presets.ts
@@ -1,13 +1,16 @@
-const path = require('path');
+const { resolve } = require('path');
 
 module.exports = [
   {
     name: '@storybook/preset-typescript',
     options: {
       tsDocgenLoaderOptions: {
-        tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
+        tsconfigPath: resolve(__dirname, '../tsconfig.json'),
       },
-      include: [path.resolve(__dirname)],
+      forkTsCheckerWebpackPluginOptions: {
+        colors: false // disables built-in colors in logger messages
+      },
+      include: [resolve(__dirname)]
     },
   },
 ];

--- a/packages/preset-typescript/README.md
+++ b/packages/preset-typescript/README.md
@@ -4,8 +4,16 @@ One-line TypeScript w/ docgen configuration for Storybook.
 
 ## Basic usage
 
+#### Using yarn
+
 ```
-yarn add -D @storybook/preset-typescript react-docgen-typescript-loader ts-loader
+yarn add -D @storybook/preset-typescript react-docgen-typescript-loader ts-loader fork-ts-checker-webpack-plugin
+```
+
+#### Using npm
+
+```
+npm install --save-dev @storybook/preset-typescript react-docgen-typescript-loader ts-loader fork-ts-checker-webpack-plugin
 ```
 
 Then add the following to `.storybook/presets.js`:
@@ -16,7 +24,7 @@ module.exports = ['@storybook/preset-typescript'];
 
 ## Advanced usage
 
-You can pass configurations into the TypeScript or Docgen loaders using the `tsLoaderOptions`, `tsDocgenLoaderOptions`, and `include` options in `.storybook/presets.js`, e.g.:
+You can pass configurations into the `TypeScript`, `Docgen` loaders or `ForkTsCheckerWebpackPlugin` using the `tsLoaderOptions`, `tsDocgenLoaderOptions`, `include` and `forkTsCheckerWebpackPluginOptions` options in `.storybook/presets.js`, e.g.:
 
 ```js
 const path = require('path');
@@ -26,16 +34,21 @@ module.exports = [
     name: '@storybook/preset-typescript',
     options: {
       tsLoaderOptions: {
-        configFile: path.resolve(__dirname, '../tsconfig.json'),
+        configFile: path.resolve(__dirname, '../tsconfig.json')
       },
       tsDocgenLoaderOptions: {
-        tsconfigPath: path.resolve(__dirname, '../tsconfig.json'),
+        tsconfigPath: path.resolve(__dirname, '../tsconfig.json')
       },
-      include: [path.resolve(__dirname, '../src')],
-    },
-  },
+      forkTsCheckerWebpackPluginOptions: {
+        colors: false // disables built-in colors in logger messages
+      },
+      include: [path.resolve(__dirname, '../src')]
+    }
+  }
 ];
 ```
+
+All available options are described in the [Options](#options) section.
 
 You also can enable TypeScript transpilation on [manager](https://storybook.js.org/docs/addons/writing-addons/) side, by setting the `transpileManager` option to `true`, e.g.:
 
@@ -51,3 +64,67 @@ module.exports = [
   },
 ];
 ```
+
+## Options
+
+### tsLoaderOptions
+
+Type: `Object`
+
+#### Default value
+
+```js
+{
+  transpileOnly: true
+}
+```
+
+[ts-loader](https://github.com/TypeStrong/ts-loader#loader-options) options. If set to `true` [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) gets enabled automatically to run the separate process for type checking.
+
+### tsDocgenLoaderOptions
+
+Type: `Object`
+
+#### Default value
+
+```js
+undefined
+```
+
+[react-docgen-typescript-loader](https://github.com/strothj/react-docgen-typescript-loader#loader-options) options.
+
+### forkTsCheckerWebpackPluginOptions
+
+Type: `Object`
+
+#### Default value
+
+```js
+undefined
+```
+
+[fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options) options. `transpileOnly` flag needs to be set to `true` in `tsLoaderOptions` to be able to set options for this webpack plugin.
+
+### include
+
+Type: [Rule condition](https://webpack.js.org/configuration/module/#rule-conditions)
+
+#### Default value
+
+```js
+undefined
+```
+
+[include rule](https://webpack.js.org/configuration/module/#ruleinclude) for `/\.tsx?$/`.
+
+### transpileManager
+
+Type: `Boolean`
+
+#### Default value
+
+```js
+false
+```
+
+Toggles TypeScript transpilation on [manager](https://storybook.js.org/docs/addons/writing-addons/) side.

--- a/packages/preset-typescript/index.js
+++ b/packages/preset-typescript/index.js
@@ -1,10 +1,19 @@
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
 function webpack(webpackConfig = {}, options = {}) {
-  const { module = {}, resolve = {} } = webpackConfig;
+  const { module = {}, resolve = {}, plugins = [] } = webpackConfig;
   const {
-    tsLoaderOptions = {},
+    tsLoaderOptions = { transpileOnly: true },
     tsDocgenLoaderOptions = {},
+    forkTsCheckerWebpackPluginOptions,
     include = [],
   } = options;
+
+  if (tsLoaderOptions.transpileOnly) {
+    plugins.push(
+      new ForkTsCheckerWebpackPlugin(forkTsCheckerWebpackPluginOptions),
+    );
+  }
 
   return {
     ...webpackConfig,
@@ -36,11 +45,22 @@ function webpack(webpackConfig = {}, options = {}) {
 }
 
 function managerWebpack(webpackConfig = {}, options = {}) {
-  const { module = {}, resolve = {} } = webpackConfig;
-  const { tsLoaderOptions, include, transpileManager = false } = options;
+  const { module = {}, resolve = {}, plugins = [] } = webpackConfig;
+  const {
+    tsLoaderOptions = { transpileOnly: true },
+    include,
+    forkTsCheckerWebpackPluginOptions,
+    transpileManager = false,
+  } = options;
 
   if (!transpileManager) {
     return webpackConfig;
+  }
+
+  if (tsLoaderOptions.transpileOnly) {
+    plugins.push(
+      new ForkTsCheckerWebpackPlugin({ forkTsCheckerWebpackPluginOptions }),
+    );
   }
 
   return {

--- a/packages/preset-typescript/package.json
+++ b/packages/preset-typescript/package.json
@@ -25,6 +25,7 @@
     "@types/storybook__react": "^3.0.9",
     "@types/webpack": "^4.39.8",
     "babel-loader": "^8.0.2",
+    "fork-ts-checker-webpack-plugin": "^3.1.0",
     "react": "^16.11.0",
     "react-docgen-typescript-loader": "^3.3.0",
     "react-dom": "^16.11.0",
@@ -34,6 +35,7 @@
   },
   "peerDependencies": {
     "@types/webpack": "*",
+    "fork-ts-checker-webpack-plugin": "*",
     "react-docgen-typescript-loader": "*",
     "ts-loader": "*",
     "typescript": "^3.4"

--- a/packages/preset-typescript/tsconfig.json
+++ b/packages/preset-typescript/tsconfig.json
@@ -11,7 +11,8 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noUnusedLocals": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules"],
   "include": ["."]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6765,6 +6765,20 @@ fork-ts-checker-webpack-plugin@3.1.0:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
+fork-ts-checker-webpack-plugin@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-3.1.0.tgz#fb411a4b2c3697e1cd7f83436d4feeacbcc70c7b"
+  integrity sha512-6OkRfjuNMNqb14f01xokcWcKV5Ekknc2FvziNpcTYru+kxIYFA2MtuuBI19MHThZnjSBhoi35Dcq+I0oUkFjmQ==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+    worker-rpc "^0.1.0"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"


### PR DESCRIPTION
# Description
Use [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) in preset typescript to make builds faster and update preset typescript documentation to cover all available options

## Motivation
https://github.com/storybookjs/presets/issues/54