### PR TITLE
Add preset-inline-svg which utilizes svg-inline-loader

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ packages/preset-ant-design
 packages/preset-scss
 packages/preset-storysource
 packages/preset-typescript
+packages/preset-inline-svg

--- a/packages/preset-create-react-app/src/helpers/checkPresets.ts
+++ b/packages/preset-create-react-app/src/helpers/checkPresets.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { logger } from '@storybook/node-logger';
 
 const incompatiblePresets = [
+  '@storybook/preset-inline-svg',
   '@storybook/preset-scss',
   '@storybook/preset-typescript',
 ];

--- a/packages/preset-inline-svg/.npmignore
+++ b/packages/preset-inline-svg/.npmignore
@@ -1,0 +1,2 @@
+.storybook
+node_modules

--- a/packages/preset-inline-svg/.storybook/Icon.js
+++ b/packages/preset-inline-svg/.storybook/Icon.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import * as circleSvg from './circle.svg';
+
+export const Icon = () => (
+  <div dangerouslySetInnerHTML={{ __html: circleSvg }} />
+);

--- a/packages/preset-inline-svg/.storybook/circle.svg
+++ b/packages/preset-inline-svg/.storybook/circle.svg
@@ -1,0 +1,3 @@
+<svg height="100" width="100">
+  <circle cx="50" cy="50" r="40" stroke-width="3" fill="black" />
+</svg>

--- a/packages/preset-inline-svg/.storybook/config.js
+++ b/packages/preset-inline-svg/.storybook/config.js
@@ -1,0 +1,7 @@
+import { configure } from '@storybook/react';
+
+const loadStories = () => {
+  require('./story');
+};
+
+configure(loadStories, module);

--- a/packages/preset-inline-svg/.storybook/presets.js
+++ b/packages/preset-inline-svg/.storybook/presets.js
@@ -1,0 +1,1 @@
+module.exports = ['@storybook/preset-inline-svg'];

--- a/packages/preset-inline-svg/.storybook/story.js
+++ b/packages/preset-inline-svg/.storybook/story.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Icon } from './Icon';
+
+storiesOf('Example', module).add('Icon', () => <Icon />);

--- a/packages/preset-inline-svg/README.md
+++ b/packages/preset-inline-svg/README.md
@@ -1,0 +1,35 @@
+# Inline SVG preset for Storybook
+
+One-line inline svg using `svg-inline-loader` for Storybook.
+
+## Basic usage
+
+```
+yarn add -D @storybook/preset-inline-svg svg-inline-loader
+```
+
+Then add the following to `.storybook/presets.js`:
+
+```js
+module.exports = ['@storybook/preset-inline-svg'];
+```
+
+## Advanced usage
+
+You can pass configurations into the preset's webpack loaders using the `svgLoaderOptions` key. See documentation for `svg-inline-loader` to learn about valid options.
+
+For example:
+
+```js
+module.exports = [
+  {
+    name: '@storybook/preset-inline-svg',
+    options: {
+      svgLoaderOptions: {
+        removeTags: true,
+        removingTags: ['circle'],
+      },
+    },
+  },
+];
+```

--- a/packages/preset-inline-svg/index.d.ts
+++ b/packages/preset-inline-svg/index.d.ts
@@ -1,0 +1,11 @@
+import { Configuration, RuleSetCondition } from 'webpack';
+
+interface Options {
+  svgLoaderOptions?: object | false;
+}
+
+declare interface PresetInlineSvg {
+  webpackFinal: (config?: Configuration) => Configuration;
+}
+
+export = PresetInlineSvg;

--- a/packages/preset-inline-svg/index.js
+++ b/packages/preset-inline-svg/index.js
@@ -1,0 +1,37 @@
+const webpackFinal = (webpackConfig = {}, options = {}) => {
+  const { module = {} } = webpackConfig;
+  const { svgLoaderOptions } = options;
+  return {
+    ...webpackConfig,
+    module: {
+      ...module,
+      rules: [
+        ...(module.rules || []).map(rule => {
+          const ruleTestString = rule.test.toString();
+          if (/svg\|?/.test(ruleTestString)) {
+            return {
+              ...rule,
+              test: new RegExp(
+                ruleTestString
+                  .replace(/svg\|?/, '') // Remove other svg rules
+                  .replace(/\//, ''), // No "/" needed when creating a new RegExp
+              ),
+            };
+          }
+          return rule;
+        }),
+        {
+          test: /\.svg$/i,
+          use: [
+            {
+              loader: 'svg-inline-loader',
+              options: svgLoaderOptions,
+            },
+          ],
+        },
+      ],
+    },
+  };
+};
+
+module.exports = { webpackFinal };

--- a/packages/preset-inline-svg/package.json
+++ b/packages/preset-inline-svg/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@storybook/preset-inline-svg",
+  "version": "0.0.1",
+  "description": "Inline SVG loader preset for Storybook",
+  "license": "MIT",
+  "main": "index.js",
+  "homepage": "https://github.com/storybookjs/presets/tree/master/packages/preset-typescript",
+  "bugs": {
+    "url": "https://github.com/storybookjs/presets/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storybookjs/presets.git",
+    "directory": "packages/preset-inline-svg"
+  },
+  "scripts": {
+    "storybook": "start-storybook -p 8008"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.7.2",
+    "@storybook/react": "^5.2.6",
+    "babel-loader": "^8.0.6",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "svg-inline-loader": "^0.8.0"
+  },
+  "peerDependencies": {
+    "svg-inline-loader": "*"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,7 +3405,7 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-loader@8.0.6, babel-loader@^8.0.2:
+babel-loader@8.0.6, babel-loader@^8.0.2, babel-loader@^8.0.6:
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
   integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
@@ -3839,6 +3839,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+big.js@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
+  integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -9018,6 +9023,11 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
+json5@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -9324,6 +9334,16 @@ loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.
     big.js "^5.2.2"
     emojis-list "^2.0.0"
     json5 "^1.0.1"
+
+loader-utils@^0.2.11:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
+  integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+    object-assign "^4.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -12660,6 +12680,16 @@ react-dom@^16.11.0:
     prop-types "^15.6.2"
     scheduler "^0.17.0"
 
+react-dom@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
+  integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.18.0"
+
 react-dom@^16.8.3:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -12871,6 +12901,15 @@ react@^16.11.0:
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
   integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
+  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -13596,6 +13635,14 @@ scheduler@^0.17.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
+  integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
@@ -13855,6 +13902,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simple-html-tokenizer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
+  integrity sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -14457,6 +14509,15 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+svg-inline-loader@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/svg-inline-loader/-/svg-inline-loader-0.8.0.tgz#7e9d905d80d0b4e68d2df21afcd08ee9e9a3ea6e"
+  integrity sha512-rynplY2eXFrdNomL1FvyTFQlP+dx0WqbzHglmNtA9M4IHRC3no2aPAl3ny9lUpJzFzFMZfWRK5YIclNU+FRePA==
+  dependencies:
+    loader-utils "^0.2.11"
+    object-assign "^4.0.1"
+    simple-html-tokenizer "^0.1.1"
 
 svg-parser@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
An inline SVG preset for Storybook to get users up & running with inline SVGs quickly. There have been questions from users about how to do this, specifically because Storybook already has an SVG rule in the Webpack config, so there is a bit of a workaround that you have to do to get this configured appropriately.

Re: https://github.com/storybookjs/storybook/issues/7987#issuecomment-554542949