### PR TITLE
docs(antd): tips for override file loader

### DIFF
--- a/packages/preset-ant-design/README.md
+++ b/packages/preset-ant-design/README.md
@@ -14,6 +14,19 @@ Then add the following to `.storybook/presets.js`:
 module.exports = ['@storybook/preset-ant-design'];
 ```
 
+If used with `preset-create-react-app`, Make sure override the default file loader.
+
+```json
+{
+  name: '@storybook/preset-create-react-app',
+  options: {
+    craOverrides: {
+      fileLoaderExcludes: ['less']
+    }
+  }
+}
+```
+
 ## Advanced usage
 
 You can customize theme variable by passing `modifyVars` options into less loader in`.storybook/presets.js`, e.g.:


### PR DESCRIPTION
Antd needs less-loader, but  `preset-create-react-app` prevents  `preset-ant-design` to override webpack config. 

This tip may save developers time.