### PR TITLE
[preset-create-react-app] fix loader path tests

### DIFF
--- a/packages/preset-create-react-app/src/helpers/processCraConfig.ts
+++ b/packages/preset-create-react-app/src/helpers/processCraConfig.ts
@@ -63,7 +63,7 @@ const processCraConfig = (
             (oneOfRule: RuleSetRule): RuleSetRule => {
               if (
                 isString(oneOfRule.loader) &&
-                oneOfRule.loader.includes('file-loader')
+                /[/\\]file-loader[/\\]/.test(oneOfRule.loader)
               ) {
                 if (isStorybook530) {
                   const excludes = [
@@ -94,7 +94,7 @@ const processCraConfig = (
               // Used for the next two rules modifications.
               const isBabelLoader =
                 isString(oneOfRule.loader) &&
-                oneOfRule.loader.includes('babel-loader');
+                /[/\\]babel-loader[/\\]/.test(oneOfRule.loader);
 
               // Target `babel-loader` and add user's Babel config.
               if (
@@ -124,13 +124,13 @@ const processCraConfig = (
                 if (options.tsDocgenLoaderOptions) {
                   plugins = _plugins.filter(
                     ([plugin]: string[]) =>
-                      !plugin.includes('babel-plugin-react-docgen'),
+                      !/[/\\]babel-plugin-react-docgen[/\\]/.test(plugin),
                   );
                   overrides = [
                     {
                       test: /\.(js|jsx)$/,
                       plugins: _plugins.filter(([plugin]: string[]) =>
-                        plugin.includes('babel-plugin-react-docgen'),
+                        /[/\\]babel-plugin-react-docgen[/\\]/.test(plugin),
                       ),
                     },
                   ];


### PR DESCRIPTION
When using pnpm, sometimes dependencies are stored in folders that include associations with other dependencies.  The loader path test will, in some cases, return a false positive, unless it is bounded with the path separator.

For example, if `url-loader` loader path is:
```sh
${workspaceRoot}/node_modules/.pnpm/registry.npmjs.org/url-loader/2.3.0_file-loader@4.3.0+webpack@4.41.2/node_modules/url-loader/dist/cjs.js
```

Then line 66 in `processCraConfig` will return a false positive, and the spread operator at line 79 will throw.
https://github.com/storybookjs/presets/blob/4fa600318b1c17edc7bd11d5eaeb1d3f5969ed2a/packages/preset-create-react-app/src/helpers/processCraConfig.ts#L58-L83

It would be possible to just include `path.sep` in the `includes()` functions, like this
```ts
oneOfRule.loader.includes(`${path.sep}file-loader${path.sep}`);
```
But I used the regular expression because it will handle potential edge cases where the separator used could be different than what is used by `path.sep`.

---

Fixes https://github.com/storybookjs/presets/issues/89