### PR TITLE
fix(preset-typescript): don't default to empty include option

### DIFF
--- a/packages/preset-typescript/index.js
+++ b/packages/preset-typescript/index.js
@@ -6,7 +6,7 @@ function webpack(webpackConfig = {}, options = {}) {
     tsLoaderOptions = { transpileOnly: true },
     tsDocgenLoaderOptions = {},
     forkTsCheckerWebpackPluginOptions,
-    include = [],
+    include,
   } = options;
 
   if (tsLoaderOptions.transpileOnly) {
@@ -15,27 +15,29 @@ function webpack(webpackConfig = {}, options = {}) {
     );
   }
 
+  const tsLoader = {
+    test: /\.tsx?$/,
+    use: [
+      {
+        loader: require.resolve('ts-loader'),
+        options: tsLoaderOptions,
+      },
+      {
+        loader: require.resolve('react-docgen-typescript-loader'),
+        options: tsDocgenLoaderOptions,
+      },
+    ],
+  };
+
+  if (include) {
+    tsLoader.include = include;
+  }
+
   return {
     ...webpackConfig,
     module: {
       ...module,
-      rules: [
-        ...(module.rules || []),
-        {
-          test: /\.tsx?$/,
-          use: [
-            {
-              loader: require.resolve('ts-loader'),
-              options: tsLoaderOptions,
-            },
-            {
-              loader: require.resolve('react-docgen-typescript-loader'),
-              options: tsDocgenLoaderOptions,
-            },
-          ],
-          include,
-        },
-      ],
+      rules: [...(module.rules || []), tsLoader],
     },
     resolve: {
       ...resolve,


### PR DESCRIPTION
Since #73 the `include` option for the typescript loader defaults to an empty array, which essentially makes it required (`[]` never matches). This PR only adds `include` to the loader if something was provided in the addons config.
Alternative approach: clarify in readme that `include` is not an advanced option but required.