### PR TITLE
Updated scss preset to accept preLoaders and postLoaders

### DIFF
--- a/packages/preset-scss/README.md
+++ b/packages/preset-scss/README.md
@@ -33,3 +33,18 @@ module.exports = [
   },
 ];
 ```
+
+You can add loaders before and after the css loaders using `preLoaders` and `postLoaders` keys.
+
+For example:
+
+```js
+module.exports = [
+  {
+    name: '@storybook/preset-scss',
+    options: {
+      postLoaders: ['postcss-loader'],
+    },
+  },
+];
+```

--- a/packages/preset-scss/index.d.ts
+++ b/packages/preset-scss/index.d.ts
@@ -1,9 +1,11 @@
 import { Configuration, RuleSetCondition } from 'webpack';
 
 interface Options {
+  preLoaders?: array;
   styleLoaderOptions?: object | false;
   cssLoaderOptions?: object | false;
   sassLoaderOptions?: object | false;
+  postLoaders?: array;
   rule?: RuleSetCondition;
 }
 

--- a/packages/preset-scss/index.js
+++ b/packages/preset-scss/index.js
@@ -14,9 +14,11 @@ function wrapLoader(loader, options) {
 function webpack(webpackConfig = {}, options = {}) {
   const { module = {} } = webpackConfig;
   const {
+    preLoaders = [],
     styleLoaderOptions,
     cssLoaderOptions,
     sassLoaderOptions,
+    postLoaders = [],
     rule = {},
   } = options;
 
@@ -30,9 +32,11 @@ function webpack(webpackConfig = {}, options = {}) {
           test: /\.s[ca]ss$/,
           ...rule,
           use: [
+            ...postLoaders,
             ...wrapLoader('style-loader', styleLoaderOptions),
             ...wrapLoader('css-loader', cssLoaderOptions),
             ...wrapLoader('sass-loader', sassLoaderOptions),
+            ...preLoaders,
           ],
         },
       ],


### PR DESCRIPTION
In my project I'm interested in adding `autoprefixer` via `postcss-loader`, but I didn't have a good way to add it with the current arguments. I've introduced `preLoaders` and `postLoaders` as a way to provide this behavior.

I'm not sure if this is the right way to go about this. Alternatively I'm curious if `postcss-loader` is something that should be included by default.