### PR TITLE
Improve compatibility of preset-typescript with Vue

### DIFF
--- a/packages/preset-typescript/index.js
+++ b/packages/preset-typescript/index.js
@@ -14,6 +14,10 @@ function webpack(webpackConfig = {}, options = {}) {
     );
   }
 
+  if (options.framework === 'vue') {
+    tsLoaderOptions.appendTsSuffixTo = [...(tsLoaderOptions.appendTsSuffixTo || []), /\.vue$/];
+  }
+
   const tsLoader = {
     test: /\.tsx?$/,
     use: [

--- a/packages/preset-typescript/package.json
+++ b/packages/preset-typescript/package.json
@@ -34,7 +34,6 @@
   "peerDependencies": {
     "@types/webpack": "*",
     "fork-ts-checker-webpack-plugin": "*",
-    "react-docgen-typescript-loader": "*",
     "ts-loader": "*",
     "typescript": "^3.4"
   },


### PR DESCRIPTION
This adds `appendTsSuffixTo` if the framework is Vue and rolls up two related PRs that help minimize additional manual configuration.

- ~Remove `react-typescript-docgen-loader` from `preset-typescript` (rollup #68)~ merged
- ~Don't default to empty include option (rollup #106)~ merged
- Add appendTsSuffixTo to tsLoader options if framework is vue

**Example repo**
https://github.com/graup/storybook-vue-typescript

This actually doesn't require any custom config now, as you can see [here](https://github.com/graup/storybook-vue-typescript/blob/master/.storybook/main.js) 🎉
Just add the preset (and apply my storybook patch, which I'll introduce back to storybook later) 