### PR TITLE
fix: resolve react-scripts path from scriptsPackageName

### DIFF
--- a/packages/preset-create-react-app/src/index.ts
+++ b/packages/preset-create-react-app/src/index.ts
@@ -1,4 +1,5 @@
-import { join, relative, resolve } from 'path';
+import { join, relative, resolve, dirname } from 'path';
+import { existsSync } from 'fs';
 import { Configuration } from 'webpack'; // eslint-disable-line import/no-extraneous-dependencies
 import { logger } from '@storybook/node-logger';
 import { mergePlugins } from './helpers/mergePlugins';
@@ -37,11 +38,21 @@ const webpack = (
   const scriptsPackageName = options[OPTION_SCRIPTS_PACKAGE];
   if (typeof scriptsPackageName === 'string') {
     try {
-      scriptsPath = require.resolve(scriptsPackageName);
+      scriptsPath = dirname(require.resolve(scriptsPackageName));
     } catch (e) {
-      logger.warn(
-        `A \`${OPTION_SCRIPTS_PACKAGE}\` was provided, but couldn't be resolved.`,
-      );
+      const fallbackPath = join(CWD, 'node_modules', scriptsPackageName);
+
+      // Fallback -- unaltered react-scripts does not define 'main' in package.json,
+      // which causes require.resolve() to fail
+      if (existsSync(fallbackPath)) {
+        logger.info(`=> Trying fallback scripts package path: ${fallbackPath}`);
+
+        scriptsPath = fallbackPath;
+      } else {
+        logger.warn(
+          `A \`${OPTION_SCRIPTS_PACKAGE}\` was provided, but couldn't be resolved.`,
+        );
+      }
     }
   }
 

--- a/packages/preset-create-react-app/src/index.ts
+++ b/packages/preset-create-react-app/src/index.ts
@@ -38,21 +38,13 @@ const webpack = (
   const scriptsPackageName = options[OPTION_SCRIPTS_PACKAGE];
   if (typeof scriptsPackageName === 'string') {
     try {
-      scriptsPath = dirname(require.resolve(scriptsPackageName));
+      scriptsPath = dirname(
+        require.resolve(`${scriptsPackageName}/package.json`),
+      );
     } catch (e) {
-      const fallbackPath = join(CWD, 'node_modules', scriptsPackageName);
-
-      // Fallback -- unaltered react-scripts does not define 'main' in package.json,
-      // which causes require.resolve() to fail
-      if (existsSync(fallbackPath)) {
-        logger.info(`=> Trying fallback scripts package path: ${fallbackPath}`);
-
-        scriptsPath = fallbackPath;
-      } else {
-        logger.warn(
-          `A \`${OPTION_SCRIPTS_PACKAGE}\` was provided, but couldn't be resolved.`,
-        );
-      }
+      logger.warn(
+        `A \`${OPTION_SCRIPTS_PACKAGE}\` was provided, but couldn't be resolved.`,
+      );
     }
   }
 

--- a/packages/preset-create-react-app/src/index.ts
+++ b/packages/preset-create-react-app/src/index.ts
@@ -1,5 +1,4 @@
 import { join, relative, resolve, dirname } from 'path';
-import { existsSync } from 'fs';
 import { Configuration } from 'webpack'; // eslint-disable-line import/no-extraneous-dependencies
 import { logger } from '@storybook/node-logger';
 import { mergePlugins } from './helpers/mergePlugins';


### PR DESCRIPTION
There is a bug in `@storybook/preset-create-react-app` which prevents the use of custom `react-scripts` packages with the `scriptsPackageName` option.

This pull request addresses the following issues:

1. Node's `require.resolve()` returns a **filename**, not the pathname of the resolved module. E.g. `require('my-custom-react-scripts') => '/path/to/node_modules/my-custom-react-scripts/index.js'`. This causes `@storybook/preset-create-react-app` to incorrectly build the path for the Webpack configuration file as `/path/to/node_modules/my-custom-react-scripts/index.js/config/webpack.config.js`.

2. `react-scripts` by default do not define a `main` entry file in `package.json`, which causes `require.resolve()` to **fail** with `MODULE_NOT_FOUND` unless the `react-scripts` fork is modified to include a main file. A fallback has been added to check if `node_modules/<custom-script-name>` directory exists and use that in the case `require.resolve()` fails.