### PR TITLE
Preset-typescript: Fix for nullish babel include

### DIFF
--- a/packages/preset-typescript/src/helpers/processConfig.ts
+++ b/packages/preset-typescript/src/helpers/processConfig.ts
@@ -26,7 +26,7 @@ export const processConfig = (
     if (isBabelRule) {
       return {
         ...rule,
-        include: [...rule.include, ...include],
+        include: [...(rule.include || []), ...include],
         test: new RegExp(
           `\\.(${['mjs', 'js', 'jsx', ...tsExtensions]
             .join('|')


### PR DESCRIPTION
## What I did

Fix case where the babel include rule is nullish, and array spread fails.

Self-merging @mrmckeb 