### PR TITLE
[preset-scss] Update README.md for addon declaration on main.js

### DIFF
--- a/packages/preset-scss/README.md
+++ b/packages/preset-scss/README.md
@@ -12,11 +12,12 @@ Then add the following to `.storybook/main.js`:
 
 ```js
 module.exports = {
-  addons: ['@storybook/preset-scss']
+  addons: ['@storybook/preset-scss'],
 };
 ```
 
 ## Advanced usage
+
 You can pass configurations by using Object addon declaration for `@storybook/preset-scss` and adding the configurations under the `option` key. You can pass configurations into the preset's webpack loaders using `styleLoaderOptions`, `cssLoaderOptions`, and `sassLoaderOptions` keys. See documentation for each respective loader to learn about valid options. You can register other addons through the string declaration as normal.
 
 ```

--- a/packages/preset-scss/README.md
+++ b/packages/preset-scss/README.md
@@ -33,3 +33,24 @@ module.exports = [
   },
 ];
 ```
+
+## Advanced usage with main.js
+Using `.storybook/presets.js` with `.storybook/main.js` is not possible anymore. You can pass the configurations through `main.js` by using Object addon declaration under the `addons` key. You can register other addons through the string declaration as normal.
+```
+module.exports = {
+  addons: [
+    {
+      name: '@storybook/preset-scss',
+      options: {
+        cssLoaderOptions: {
+           modules: true,
+           localIdentName: '[name]__[local]--[hash:base64:5]',
+        }
+      }
+    },
+    // You can add other presets/addons by using the string declaration
+    '@storybook/preset-typescript',
+    '@storybook/addon-actions',
+  ]
+}
+```

--- a/packages/preset-scss/README.md
+++ b/packages/preset-scss/README.md
@@ -8,34 +8,17 @@ One-line SCSS configuration for storybook.
 yarn add -D @storybook/preset-scss css-loader sass-loader style-loader
 ```
 
-Then add the following to `.storybook/presets.js`:
+Then add the following to `.storybook/main.js`:
 
 ```js
-module.exports = ['@storybook/preset-scss'];
+module.exports = {
+  addons: ['@storybook/preset-scss']
+};
 ```
 
 ## Advanced usage
+You can pass configurations by using Object addon declaration for `@storybook/preset-scss` and adding the configurations under the `option` key. You can pass configurations into the preset's webpack loaders using `styleLoaderOptions`, `cssLoaderOptions`, and `sassLoaderOptions` keys. See documentation for each respective loader to learn about valid options. You can register other addons through the string declaration as normal.
 
-You can pass configurations into the preset's webpack loaders using `styleLoaderOptions`, `cssLoaderOptions`, and `sassLoaderOptions` keys. See documentation for each respective loader to learn about valid options.
-
-For example:
-
-```js
-module.exports = [
-  {
-    name: '@storybook/preset-scss',
-    options: {
-      cssLoaderOptions: {
-        modules: true,
-        localIdentName: '[name]__[local]--[hash:base64:5]',
-      },
-    },
-  },
-];
-```
-
-## Advanced usage with main.js
-Using `.storybook/presets.js` with `.storybook/main.js` is not possible anymore. You can pass the configurations through `main.js` by using Object addon declaration under the `addons` key. You can register other addons through the string declaration as normal.
 ```
 module.exports = {
   addons: [


### PR DESCRIPTION
The readme for `preset-scss` does not have documentation for declaring the options for addons/preset on main.js. This is needed as using preset.js and main.js is not supported right now.