### PR TITLE
Update to less-loader@6.0.0 format

### DIFF
--- a/packages/preset-ant-design/index.js
+++ b/packages/preset-ant-design/index.js
@@ -18,8 +18,10 @@ const webpack = (webpackConfig = {}, options = { lessOptions: {} }) => {
             {
               loader: 'less-loader',
               options: {
-                ...options.lessOptions,
-                javascriptEnabled: true,
+                lessOptions : {
+                  ...options.lessOptions,
+                  javascriptEnabled: true,
+                }
               },
             },
           ],


### PR DESCRIPTION
lessOptions are now spread into options.lessOptions, not directly in options

fix #133 