### PR TITLE
Update to less-loader@6.0.0

### DIFF
--- a/packages/preset-ant-design/index.js
+++ b/packages/preset-ant-design/index.js
@@ -18,8 +18,10 @@ const webpack = (webpackConfig = {}, options = { lessOptions: {} }) => {
             {
               loader: 'less-loader',
               options: {
-                ...options.lessOptions,
-                javascriptEnabled: true,
+                lessOptions: {
+                  ...options.lessOptions,
+                  javascriptEnabled: true,
+                },
               },
             },
           ],

--- a/packages/preset-ant-design/package.json
+++ b/packages/preset-ant-design/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-import": "^1.13.0",
     "css-loader": "^3.4.2",
     "less": "^3.11.1",
-    "less-loader": "^5.0.0",
+    "less-loader": "^6.0.0",
     "style-loader": "^1.1.3"
   },
   "publishConfig": {


### PR DESCRIPTION
lessOptions are now spread into options.lessOptions, not directly in options

fix #133 