### PR TITLE
Use * on node-logger dependency version

### DIFF
--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@storybook/node-logger": "^5.3.17",
+    "@storybook/node-logger": "*",
     "@types/babel__core": "^7.1.6",
     "@types/webpack": "^4.41.7",
     "pnp-webpack-plugin": "^1.6.4",


### PR DESCRIPTION
Why ?

Because when launching e2e with verdaccio, this preset is installed in an environment where @storybook/node-logger@5.3.17 doesn't exists