### PR TITLE
Typescript: remove unused tsLoaderOptions from example

### DIFF
--- a/packages/preset-typescript/README.md
+++ b/packages/preset-typescript/README.md
@@ -46,9 +46,6 @@ module.exports = {
     {
       name: '@storybook/preset-typescript',
       options: {
-        tsLoaderOptions: {
-          configFile: path.resolve(__dirname, './tsconfig.json'),
-        },
         forkTsCheckerWebpackPluginOptions: {
           colors: false, // disables built-in colors in logger messages
         },


### PR DESCRIPTION
Seems like `tsLoaderOptions` do nothing now since preset-typescript uses babel-loader by default (https://github.com/storybookjs/presets/pull/115).

__

Also I have some thoughts to discuss about docs around Storybook and TypeScript (not sure this issue is a good place for it though).

To add more context: I have preact+typescript project and tried to use preset-typescript instead of customizing webpack config. Having `"jsxFactory": "h"` in my tsconfig.json I removed `/** jsx h */` comments from story files. This led to `"h is not defined"` error.

I spent some time trying to figure out why preset-typescript didn't use my tsconfig.json before  learning that ts-loader is not used in the latest version. Then I tried to set `{ pragma: 'h' }` for babel-loader but didn't have success with it and finally went with old "customize webpack config" way :)

So, what I propose:
1. Maybe it's worth to add warning in README that preset-typescript uses `babel-loader` instead of `ts-loader` since 3.0?
2. Also it seems like "manual configuration" should be mentioned as a third alternative suitable for some use cases in the beginning of [TS config docs](https://storybook.js.org/docs/configurations/typescript-config/). Maybe something like "if you use CRA - `preset-create-react-app` is for you, if you transpile TS via babel-loader - try `preset-typescript`, if you use ts-loader or need more control - go with manual configuration". Presets are advertised as "the fastest and easiest way to use TypeScript" now but sometimes manual configuration may be faster.