### PR TITLE
SCSS: Update modules example in readme

### DIFF
--- a/packages/preset-scss/README.md
+++ b/packages/preset-scss/README.md
@@ -27,8 +27,10 @@ module.exports = {
       name: '@storybook/preset-scss',
       options: {
         cssLoaderOptions: {
-           modules: true,
-           localIdentName: '[name]__[local]--[hash:base64:5]',
+           modules: {
+              mode: 'local',
+              localIdentName: '[name]__[local]--[hash:base64:5]',
+           },
         }
       }
     },


### PR DESCRIPTION
`localIdentName` is located inside the `modules` option, not next to it, see [here](https://github.com/webpack-contrib/css-loader#localidentname)

Updated the example to use `mode: 'local'` since that is the same as `modules: true`, see [here](https://github.com/webpack-contrib/css-loader#mode). I guess we could also omit it, not sure what's preferred.

**Update**
#64 seems to fix the same issue but hasn't been merged?