### PR TITLE
fix(scss): add missing node-sass peer dependency

### DIFF
--- a/packages/preset-scss/README.md
+++ b/packages/preset-scss/README.md
@@ -5,7 +5,7 @@ One-line SCSS configuration for storybook.
 ## Basic usage
 
 ```
-yarn add -D @storybook/preset-scss css-loader sass-loader style-loader
+yarn add -D @storybook/preset-scss node-sass css-loader sass-loader style-loader
 ```
 
 Then add the following to `.storybook/main.js`:

--- a/packages/preset-scss/package.json
+++ b/packages/preset-scss/package.json
@@ -31,6 +31,7 @@
   },
   "peerDependencies": {
     "css-loader": "*",
+    "node-sass": "*",
     "sass-loader": "*",
     "style-loader": "*"
   },


### PR DESCRIPTION
I think this could be related to #118. I just tried to use this in a project and when building the static storybook on Netlify I got the following error:

```bash
11:40:00 PM: info => Loading config/preview file in "./.storybook".
11:40:00 PM: info => Adding stories defined in ".storybook/main.js".
11:40:00 PM: info => Loading custom Webpack config (full-control mode).
11:40:00 PM: info => Using base config because react-scripts is not installed.
11:40:00 PM: info => Compiling preview..
11:40:18 PM: ERR! => Failed to build the preview
11:40:18 PM: ERR! ./src/styles.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./src/styles.scss)
11:40:18 PM: ERR! Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
11:40:18 PM: ERR! Error: Cannot find module 'sass'
11:40:18 PM: ERR!     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
11:40:18 PM: ERR!     at Function.Module._load (internal/modules/cjs/loader.js:562:25)
11:40:18 PM: ERR!     at Module.require (internal/modules/cjs/loader.js:692:17)
11:40:18 PM: ERR!     at require (internal/modules/cjs/helpers.js:25:18)
11:40:18 PM: ERR!     at getDefaultSassImplementation (/opt/build/repo/node_modules/sass-loader/dist/utils.js:42:10)
11:40:18 PM: ERR!     at getSassImplementation (/opt/build/repo/node_modules/sass-loader/dist/utils.js:50:30)
11:40:18 PM: ERR!     at Object.loader (/opt/build/repo/node_modules/sass-loader/dist/index.js:34:59)
11:40:18 PM: ERR!  @ ./src/styles.scss 2:26-131
11:40:18 PM: ERR!  @ ./.storybook/config.js
11:40:18 PM: ERR!  @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/config.js ./.storybook/generated-entry.js
11:40:18 PM: (node:1616) UnhandledPromiseRejectionWarning: [object Object]
11:40:18 PM: (node:1616) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
11:40:18 PM: (node:1616) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
11:40:18 PM: error Command failed with exit code 1.
```

Installing `node-sass` resolved it.