### PR TITLE
fix(preset-scss): require.resolve webpack loaders

### DIFF
--- a/packages/preset-scss/index.js
+++ b/packages/preset-scss/index.js
@@ -30,9 +30,9 @@ function webpack(webpackConfig = {}, options = {}) {
           test: /\.s[ca]ss$/,
           ...rule,
           use: [
-            ...wrapLoader('style-loader', styleLoaderOptions),
-            ...wrapLoader('css-loader', cssLoaderOptions),
-            ...wrapLoader('sass-loader', sassLoaderOptions),
+            ...wrapLoader(require.resolve('style-loader'), styleLoaderOptions),
+            ...wrapLoader(require.resolve('css-loader'), cssLoaderOptions),
+            ...wrapLoader(require.resolve('sass-loader'), sassLoaderOptions),
           ],
         },
       ],


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@storybook/preset-scss` is passing webpack loaders as strings instead of their absolute location causing it to rely on hoisting to place them next to `@storybook/core` which is not guaranteed

**How did you fix it?**

Use `require.resolve` to get the absolute path of the loaders