### PR TITLE
Fixed 'Invalid options object' error

### DIFF
--- a/packages/preset-ant-design/index.js
+++ b/packages/preset-ant-design/index.js
@@ -18,8 +18,10 @@ const webpack = (webpackConfig = {}, options = { lessOptions: {} }) => {
             {
               loader: 'less-loader',
               options: {
-                ...options.lessOptions,
-                javascriptEnabled: true,
+                lessOptions: {
+                  ...options.lessOptions,
+                  javascriptEnabled: true,
+                },
               },
             },
           ],


### PR DESCRIPTION
After less-loader's version upgrade, such error shown during attempt to start storybook

```
ERROR in ./node_modules/antd/lib/dropdown/style/index.less (./node_modules/css-loader/dist/cjs.js!./node_modules/less-loader/dist/cjs.js??ref--7-2!./node_modules/less-loader/dist/cjs.js??ref--12-0!./node_modules/antd/lib/dropdown/style/index.less)
Module build failed (from ./node_modules/less-loader/dist/cjs.js):
ValidationError: Invalid options object. Less Loader has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'modifyVars'. These properties are valid:
   object { lessOptions?, additionalData?, sourceMap?, webpackImporter? }
```

It requires to set lessOptions inside less-options object:

Before:
```
 presets: [
    {
      name: '@storybook/preset-ant-design',
      options: {
        javascriptEnabled: true,
        modifyVars: theme,
      },
    },
  ],
```

After:
```
  presets: [
    {
      name: '@storybook/preset-ant-design',
      options: {
        lessOptions: {
          javascriptEnabled: true,
          modifyVars: theme,
        },
      },
    },
  ],
```
