### PR TITLE
preset-create-react-app: Support monorepos and PnP

### DIFF
--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist & tsc",
+    "build": "rm -rf dist && tsc",
     "build-watch": "yarn build -w",
     "build-storybook": "exit 0;",
     "prepublishOnly": "yarn build"

--- a/packages/preset-create-react-app/src/helpers/getReactScriptsPath.ts
+++ b/packages/preset-create-react-app/src/helpers/getReactScriptsPath.ts
@@ -1,5 +1,5 @@
 import { readFileSync, realpathSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 
 export const getReactScriptsPath = (): string => {
   const cwd = process.cwd();
@@ -46,39 +46,11 @@ export const getReactScriptsPath = (): string => {
    * Try to find the `react-scripts` package by name (won't catch forked scripts packages).
    */
   try {
-    const scriptsPath = require.resolve('react-scripts');
+    const scriptsPath = dirname(require.resolve('react-scripts/package.json'));
     return scriptsPath;
   } catch (e) {
     // NOOP
   }
 
   return '';
-};
-
-export const getReactScriptsPathWithYarnPnp = (
-  packageName = 'react-scripts',
-): string => {
-  /*
-   * Use Plug'n'Play API to introspect the dependency tree at runtime.
-   * See https://yarnpkg.com/advanced/pnpapi for more.
-   */
-  // eslint-disable-next-line import/no-unresolved, @typescript-eslint/no-var-requires, global-require
-  const pnpApi = require('pnpapi');
-
-  // Get list of all dependencies of the project
-  const { packageDependencies } = pnpApi.getPackageInformation({
-    name: null,
-    reference: null,
-  });
-
-  /*
-   * Get location of the package named `packageName`, this package must be
-   * listed as dependency to be able to find it's location (and no more just
-   * be present in node_modules folder)
-   */
-  const { packageLocation } = pnpApi.getPackageInformation(
-    pnpApi.getLocator(packageName, packageDependencies.get(packageName)),
-  );
-
-  return packageLocation;
 };

--- a/packages/preset-create-react-app/src/index.ts
+++ b/packages/preset-create-react-app/src/index.ts
@@ -5,22 +5,15 @@ import { logger } from '@storybook/node-logger';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 import ReactDocgenTypescriptPlugin from 'react-docgen-typescript-plugin';
 import { mergePlugins } from './helpers/mergePlugins';
-import {
-  getReactScriptsPath,
-  getReactScriptsPathWithYarnPnp,
-} from './helpers/getReactScriptsPath';
+import { getReactScriptsPath } from './helpers/getReactScriptsPath';
 import { processCraConfig } from './helpers/processCraConfig';
 import { checkPresets } from './helpers/checkPresets';
 import { getModulePath } from './helpers/getModulePath';
 import { StorybookConfig } from './types';
 
 const CWD = process.cwd();
-// When operating under PnP environments, this value will be set to a number
-// indicating the version of the PnP standard, see: https://yarnpkg.com/advanced/pnpapi#processversionspnp
-const IS_USING_YARN_PNP = typeof process.versions.pnp !== 'undefined';
-const REACT_SCRIPTS_PATH = IS_USING_YARN_PNP
-  ? getReactScriptsPathWithYarnPnp()
-  : getReactScriptsPath();
+
+const REACT_SCRIPTS_PATH = getReactScriptsPath();
 const OPTION_SCRIPTS_PACKAGE = 'scriptsPackageName';
 
 // Ensures that assets are served from the correct path when Storybook is built.
@@ -66,9 +59,11 @@ export const webpack = (
   const scriptsPackageName = options[OPTION_SCRIPTS_PACKAGE];
   if (typeof scriptsPackageName === 'string') {
     try {
-      scriptsPath = IS_USING_YARN_PNP
-        ? getReactScriptsPathWithYarnPnp(scriptsPackageName)
-        : dirname(require.resolve(`${scriptsPackageName}/package.json`));
+      scriptsPath = dirname(
+        require.resolve(`${scriptsPackageName}/package.json`, {
+          paths: [options.configDir],
+        }),
+      );
     } catch (e) {
       logger.warn(
         `A \`${OPTION_SCRIPTS_PACKAGE}\` was provided, but couldn't be resolved.`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

- `@storybook/preset-create-react-app` is using the `pnpapi` directly to query the **top level** workspace to try to locate `react-scripts` but this doesn't work when in a monorepo where the top level probably doesn't depend on `react-scripts` and even if it did, it might not be the same version as the one the workspace depends on
- `react-scripts` doesn't have a `main` field nor a `index` file so resolving it fails

Fixes https://github.com/storybookjs/presets/issues/58
Fixes https://github.com/storybookjs/presets/issues/161
Fixes https://github.com/storybookjs/presets/issues/168
Fixes https://github.com/storybookjs/storybook/issues/10078
Closes https://github.com/storybookjs/presets/pull/166

**How did you fix it?**

- Remove the PnP specific logic as querying the pnpapi directly is usually not the answer
- Resolve the `package.json` of `react-scripts` to be able to locate it