### PR TITLE
Update preset-ant-design

### DIFF
--- a/packages/preset-ant-design/index.js
+++ b/packages/preset-ant-design/index.js
@@ -18,8 +18,10 @@ const webpack = (webpackConfig = {}, options = { lessOptions: {} }) => {
             {
               loader: 'less-loader',
               options: {
-                ...options.lessOptions,
-                javascriptEnabled: true,
+                lessOptions: {
+                  ...options.lessOptions,
+                  javascriptEnabled: true,
+                },
               },
             },
           ],


### PR DESCRIPTION
less-loader moved some options to the `lessOptions` option, so this is needed to work with v6.0.0+

Changelog of less-loader:
https://github.com/webpack-contrib/less-loader/releases/tag/v6.0.0

I confirmed this change works with latest Ant Design.