### PR TITLE
fix: duplicate babel typescript preset

### DIFF
--- a/packages/preset-typescript/src/index.ts
+++ b/packages/preset-typescript/src/index.ts
@@ -18,9 +18,13 @@ export const babel = (
     options.framework === 'vue'
       ? babelPresetVueTypeScript
       : babelPresetTypeScript;
+
+  const patchedPresets =
+    !presets || presets.includes(preset) ? presets : [...presets, preset];
+
   return {
     ...config,
-    presets: [...(presets as PluginItem[]), preset],
+    presets: patchedPresets as PluginItem[],
   };
 };
 


### PR DESCRIPTION
I am not entirely sure what causes it to happen but using the typescript-preset I got babel errors that presets were doubled, caused by `@storybook/preset-typescript` adding the typescript preset eventhough it was already present (again, not sure what has already added it before the preset kicks in). 

This PR adds an additional check to avoid adding the babel-preset if it's already present in the list of presets passed to the storybook-preset.

Not sure what's causing the CI checks to fail, it doesn't seem to be caused by the changes made following [the error](https://github.com/storybookjs/presets/pull/196/checks?check_run_id=2266026868#step:7:2933).