### PR TITLE
preset-create-react-app - make sure to always return valid rule

### DIFF
--- a/packages/preset-create-react-app/src/helpers/processCraConfig.ts
+++ b/packages/preset-create-react-app/src/helpers/processCraConfig.ts
@@ -45,7 +45,7 @@ export const processCraConfig = (
     if (testMatch(rule, '.jsx')) {
       const newRule = {
         ...rule,
-        include: [include as string, configDir],
+        include: [include as string, configDir].filter(Boolean),
       };
       return [...rules, newRule];
     }
@@ -79,7 +79,7 @@ export const processCraConfig = (
                   exclude: [
                     ...(oneOfRule.exclude as RuleSetConditions),
                     excludeRegex,
-                  ],
+                  ].filter(Boolean),
                 };
               }
               return {};
@@ -90,7 +90,9 @@ export const processCraConfig = (
               return {
                 ...oneOfRule,
                 include: isStorybook530 ? undefined : [configDir],
-                exclude: [oneOfRule.exclude as RegExp, /@storybook/],
+                exclude: [oneOfRule.exclude as RegExp, /@storybook/].filter(
+                  Boolean,
+                ),
               };
             }
 
@@ -122,7 +124,7 @@ export const processCraConfig = (
 
               return {
                 ...oneOfRule,
-                include: [_include as string, configDir],
+                include: [_include as string, configDir].filter(Boolean),
                 options: {
                   ...(ruleOptions as Record<string, unknown>),
                   extends: _extends,


### PR DESCRIPTION
As per Webpack spec, providing `include/exclude` parameter when defining rule is not mandatory.
When using `preset-create-react-app` with default `CRA` setup, everything works fine.
However, for people using customized `CRA` (such as `craco`, `react-app-rewired`) this can cause an issue if the rule that gets modified as part of this preset does not contain such a parameter (include/exclude). Preset will produce an array containing an `undefined` value in it which will later cause a crash.

![image](https://user-images.githubusercontent.com/144215/131973445-461db6a2-034f-4a15-8e7a-296cf747d770.png)

Such a rule has been already introduced to [CRA codebase](https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/config/webpack.config.js#L332) but has not been released yet.