### PR TITLE
CRA: Add compatibility for CRA v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.13",
-    "@types/webpack": "^4.41.26",
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "@typescript-eslint/parser": "^4.15.0",
     "eslint": "^7.19.0",

--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -29,7 +29,7 @@
     "@types/webpack": "^4.41.13",
     "babel-plugin-react-docgen": "^4.1.0",
     "pnp-webpack-plugin": "^1.6.4",
-    "react-docgen-typescript-plugin": "^1.0.0",
+    "@storybook/react-docgen-typescript-plugin": "canary",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -26,9 +26,8 @@
   "dependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@types/babel__core": "^7.1.7",
-    "@types/webpack": "^4.41.13",
     "babel-plugin-react-docgen": "^4.1.0",
-    "pnp-webpack-plugin": "^1.6.4",
+    "pnp-webpack-plugin": "^1.7.0",
     "@storybook/react-docgen-typescript-plugin": "canary",
     "semver": "^7.3.5"
   },

--- a/packages/preset-create-react-app/package.json
+++ b/packages/preset-create-react-app/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
     "@types/babel__core": "^7.1.7",
     "babel-plugin-react-docgen": "^4.1.0",
     "pnp-webpack-plugin": "^1.7.0",

--- a/packages/preset-create-react-app/src/helpers/mergePlugins.ts
+++ b/packages/preset-create-react-app/src/helpers/mergePlugins.ts
@@ -11,16 +11,16 @@ export const mergePlugins = (...args: Plugin[]): Plugin[] =>
     ) {
       return plugins;
     }
-    let updatedPlugin = plugin;
-    if (plugin.constructor.name === 'ReactRefreshPlugin') {
-      // Storybook uses webpack-hot-middleware
-      // https://github.com/storybookjs/presets/issues/177
+    const updatedPlugin = plugin;
+    // if (plugin.constructor.name === 'ReactRefreshPlugin') {
+    //   // Storybook uses webpack-hot-middleware
+    //   // https://github.com/storybookjs/presets/issues/177
 
-      updatedPlugin = new ReactRefreshWebpackPlugin({
-        overlay: {
-          sockIntegration: 'whm',
-        },
-      });
-    }
+    //   updatedPlugin = new ReactRefreshWebpackPlugin({
+    //     overlay: {
+    //       sockIntegration: 'whm',
+    //     },
+    //   });
+    // }
     return [...plugins, updatedPlugin];
   }, [] as Plugin[]);

--- a/packages/preset-create-react-app/src/helpers/mergePlugins.ts
+++ b/packages/preset-create-react-app/src/helpers/mergePlugins.ts
@@ -12,16 +12,16 @@ export const mergePlugins = (...args: Plugin[]): Plugin[] =>
     ) {
       return plugins;
     }
-    const updatedPlugin = plugin;
-    // if (plugin.constructor.name === 'ReactRefreshPlugin') {
-    //   // Storybook uses webpack-hot-middleware
-    //   // https://github.com/storybookjs/presets/issues/177
+    let updatedPlugin = plugin;
+    if (plugin.constructor.name === 'ReactRefreshPlugin') {
+      // Storybook uses webpack-hot-middleware
+      // https://github.com/storybookjs/presets/issues/177
 
-    //   updatedPlugin = new ReactRefreshWebpackPlugin({
-    //     overlay: {
-    //       sockIntegration: 'whm',
-    //     },
-    //   });
-    // }
+      updatedPlugin = new ReactRefreshWebpackPlugin({
+        overlay: {
+          sockIntegration: 'whm',
+        },
+      });
+    }
     return [...plugins, updatedPlugin];
   }, [] as Plugin[]);

--- a/packages/preset-create-react-app/src/helpers/processCraConfig.ts
+++ b/packages/preset-create-react-app/src/helpers/processCraConfig.ts
@@ -45,7 +45,7 @@ export const processCraConfig = (
     if (testMatch(rule, '.jsx')) {
       const newRule = {
         ...rule,
-        include: [include as string, configDir],
+        include: [include as string, configDir].filter(Boolean),
       };
       return [...rules, newRule];
     }
@@ -122,7 +122,7 @@ export const processCraConfig = (
 
               return {
                 ...oneOfRule,
-                include: [_include as string, configDir],
+                include: [_include as string, configDir].filter(Boolean),
                 options: {
                   ...(ruleOptions as Record<string, unknown>),
                   extends: _extends,

--- a/packages/preset-create-react-app/src/helpers/processCraConfig.ts
+++ b/packages/preset-create-react-app/src/helpers/processCraConfig.ts
@@ -61,10 +61,8 @@ export const processCraConfig = (
         ...rules,
         {
           oneOf: oneOf.map((oneOfRule: RuleSetRule): RuleSetRule => {
-            if (
-              isString(oneOfRule.loader) &&
-              /[/\\]file-loader[/\\]/.test(oneOfRule.loader)
-            ) {
+            // @ts-expect-error - This is a conflict with types bundled in Storybook.
+            if (oneOfRule.type === 'asset/resource') {
               if (isStorybook530) {
                 const excludes = [
                   'ejs', // Used within Storybook.

--- a/packages/preset-create-react-app/src/index.ts
+++ b/packages/preset-create-react-app/src/index.ts
@@ -3,7 +3,7 @@ import { Configuration, ResolveLoader, ResolvePlugin } from 'webpack'; // eslint
 import semver from 'semver';
 import { logger } from '@storybook/node-logger';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
-import ReactDocgenTypescriptPlugin from 'react-docgen-typescript-plugin';
+import ReactDocgenTypescriptPlugin from '@storybook/react-docgen-typescript-plugin';
 import { mergePlugins } from './helpers/mergePlugins';
 import { getReactScriptsPath } from './helpers/getReactScriptsPath';
 import { processCraConfig } from './helpers/processCraConfig';
@@ -112,17 +112,7 @@ export const webpack = (
 
   // CRA uses the `ModuleScopePlugin` to limit suppot to the `src` directory.
   // Here, we select the plugin and modify its configuration to include Storybook config directory.
-  const plugins =
-    craWebpackConfig.resolve?.plugins?.map(
-      (plugin: ResolvePlugin | { appSrcs: string[] }) => {
-        if ('appSrcs' in plugin) {
-          // Mutate the plugin directly as opposed to recreating it.
-          // eslint-disable-next-line no-param-reassign
-          plugin.appSrcs = [...plugin.appSrcs, resolve(options.configDir)];
-        }
-        return plugin;
-      },
-    ) ?? [];
+  const plugins = [] as any;
 
   // NOTE: These are set by default in Storybook 6.
   const isStorybook6 = semver.gte(options.packageJson.version || '', '6.0.0');

--- a/packages/preset-create-react-app/src/index.ts
+++ b/packages/preset-create-react-app/src/index.ts
@@ -1,4 +1,4 @@
-import { join, relative, resolve, dirname } from 'path';
+import { join, relative, dirname } from 'path';
 import { Configuration, ResolveLoader, ResolvePlugin } from 'webpack'; // eslint-disable-line import/no-extraneous-dependencies
 import semver from 'semver';
 import { logger } from '@storybook/node-logger';
@@ -106,13 +106,9 @@ export const webpack = (
     webpackConfig.mode,
   ) as Configuration;
 
-  // Select the relevent CRA rules and add the Storybook config directory.
+  // Select the relevant CRA rules and add the Storybook config directory.
   logger.info(`=> Modifying Create React App rules.`);
   const craRules = processCraConfig(craWebpackConfig, options);
-
-  // CRA uses the `ModuleScopePlugin` to limit suppot to the `src` directory.
-  // Here, we select the plugin and modify its configuration to include Storybook config directory.
-  const plugins = [] as any;
 
   // NOTE: These are set by default in Storybook 6.
   const isStorybook6 = semver.gte(options.packageJson.version || '', '6.0.0');
@@ -153,7 +149,7 @@ export const webpack = (
         join(REACT_SCRIPTS_PATH, 'node_modules'),
         ...getModulePath(CWD),
       ],
-      plugins: [...plugins, PnpWebpackPlugin] as ResolvePlugin[],
+      plugins: [PnpWebpackPlugin as unknown as ResolvePlugin],
     },
     resolveLoader,
   };

--- a/packages/preset-create-react-app/src/types.ts
+++ b/packages/preset-create-react-app/src/types.ts
@@ -1,5 +1,5 @@
 import type { PluginItem } from '@babel/core';
-import type { PluginOptions as RDTSPluginOptions } from 'react-docgen-typescript-plugin';
+import type { PluginOptions as RDTSPluginOptions } from '@storybook/react-docgen-typescript-plugin';
 
 export type Preset = string | { name: string };
 

--- a/packages/preset-create-react-app/tsconfig.json
+++ b/packages/preset-create-react-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   }
 }

--- a/packages/preset-ie11/package.json
+++ b/packages/preset-ie11/package.json
@@ -28,7 +28,6 @@
     "@babel/preset-env": "^7.12.7",
     "@storybook/node-logger": "*",
     "@types/babel__core": "^7.1.6",
-    "@types/webpack": "^4.41.13",
     "babel-loader": "^8.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,7 +2948,7 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@^4.41.13", "@types/webpack@^4.41.26", "@types/webpack@^4.41.7", "@types/webpack@^4.41.8":
+"@types/webpack@^4.41.26", "@types/webpack@^4.41.7", "@types/webpack@^4.41.8":
   version "4.41.30"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.30.tgz#fd3db6d0d41e145a8eeeafcd3c4a7ccde9068ddc"
   integrity sha512-GUHyY+pfuQ6haAfzu4S14F+R5iGRwN6b2FRNJY7U0NilmFAqbsOfK6j1HwuLBAqwRIT+pVdNDJGJ6e8rpp0KHA==
@@ -11036,10 +11036,17 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
-pnp-webpack-plugin@1.6.4, pnp-webpack-plugin@^1.6.4:
+pnp-webpack-plugin@1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
+  dependencies:
+    ts-pnp "^1.1.6"
+
+pnp-webpack-plugin@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.7.0.tgz#65741384f6d8056f36e2255a8d67ffc20866f5c9"
+  integrity sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==
   dependencies:
     ts-pnp "^1.1.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,6 +2369,19 @@
     react-docgen-typescript "^2.0.0"
     tslib "^2.0.0"
 
+"@storybook/react-docgen-typescript-plugin@canary":
+  version "1.0.2-canary.187a82f.0"
+  resolved "https://registry.yarnpkg.com/@storybook/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.2-canary.187a82f.0.tgz#e53f254959f8f0468e0cfdd539433ec0d957c13b"
+  integrity sha512-Yxiw8de2kw3lNsKU++WK1GD1gavJQoKmOh4L/7N3DG7z/8YEFj/vTNeFZ5NiLdf5YTQP4oEI24gawbIU1BjeWQ==
+  dependencies:
+    debug "^4.1.1"
+    endent "^2.0.1"
+    find-cache-dir "^3.3.1"
+    flat-cache "^3.0.4"
+    micromatch "^4.0.2"
+    react-docgen-typescript "^2.0.0"
+    tslib "^2.0.0"
+
 "@storybook/react@^6.1.17":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/react/-/react-6.3.2.tgz#6c9b2e010874ccc991a511cfed87b134ef02bc6d"
@@ -12496,25 +12509,6 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-docgen-typescript-plugin@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.0.tgz#f3b13df1acf3126957c689c47cd8552d42734feb"
-  integrity sha512-Akc7EtryOA4d2yOX27B5ii+hyf/k15ymb01uB+VnRgtTAdfeDCmNPvyLbRJ6pRNYOuFlEBe1YfCH73bTPtpYVQ==
-  dependencies:
-    debug "^4.1.1"
-    endent "^2.0.1"
-    find-cache-dir "^3.3.1"
-    flat-cache "^3.0.4"
-    micromatch "^4.0.2"
-    react-docgen-typescript "^1.22.0"
-    tslib "^2.0.0"
-    webpack-sources "^2.2.0"
-
-react-docgen-typescript@^1.22.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz#00232c8e8e47f4437cac133b879b3e9437284bee"
-  integrity sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==
-
 react-docgen-typescript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.0.0.tgz#0f684350159ae4d2d556f8bc241a74669753944b"
@@ -13795,7 +13789,7 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^2.0.0, source-list-map@^2.0.1:
+source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -15342,14 +15336,6 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
-
-webpack-sources@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
-  integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==
-  dependencies:
-    source-list-map "^2.0.1"
-    source-map "^0.6.1"
 
 webpack-virtual-modules@^0.2.2:
   version "0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,6 +1829,21 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.1.tgz#7e98d6f22c360e1dd00909f5fa9d0f6ecc263292"
+  integrity sha512-ccap6o7+y5L8cnvkZ9h8UXCGyy2DqtwCD+/N3Yru6lxMvcdkPKtdx13qd7sAC9s5qZktOmWf9lfUjsGOvSdYhg==
+  dependencies:
+    ansi-html-community "^0.0.8"
+    common-path-prefix "^3.0.0"
+    core-js-pure "^3.8.1"
+    error-stack-parser "^2.0.6"
+    find-up "^5.0.0"
+    html-entities "^2.1.0"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+    source-map "^0.7.3"
+
 "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
@@ -3399,6 +3414,11 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-html-community@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
+
 ansi-html@0.0.7, ansi-html@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -4913,6 +4933,11 @@ commander@^6.2.0, commander@^6.2.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
+common-path-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
+  integrity sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==
+
 common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
@@ -5089,6 +5114,11 @@ core-js-pure@^3.15.0, core-js-pure@^3.8.2:
   version "3.15.2"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.2.tgz#c8e0874822705f3385d3197af9348f7c9ae2e3ce"
   integrity sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==
+
+core-js-pure@^3.8.1:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.18.0.tgz#e5187347bae66448c9e2d67c01c34c4df3261dc5"
+  integrity sha512-ZnK+9vyuMhKulIGqT/7RHGRok8RtkHMEX/BGPHkHx+ouDkq+MUvf9mfIgdqhpmPDu8+V5UtRn/CbCRc9I4lX4w==
 
 core-js@^2.4.0:
   version "2.6.12"
@@ -7745,6 +7775,11 @@ html-entities@^1.2.0, html-entities@^1.2.1, html-entities@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
   integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
+
+html-entities@^2.1.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.2.tgz#760b404685cb1d794e4f4b744332e3b00dcfe488"
+  integrity sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==
 
 html-escaper@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
This PR makes the required updates to allow the preset to work with CRAv5.

Due to an issue with CRAv5 alpha (fixed in the next release), the latest version of `postcss-normalize` should be manually installed.